### PR TITLE
Update kind-of to 6.0.3 explicitly in package.json to fix vulnerablity

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "kind-of": "^6.0.2"
+    "kind-of": "^6.0.3"
   },
   "devDependencies": {
     "define-property": "^2.0.0",


### PR DESCRIPTION
kind-of@6.0.2 has a vulnerability. https://snyk.io/test/npm/kind-of/6.0.2
Pointing out the fixed version explicitly is safer.